### PR TITLE
Improve form page comments

### DIFF
--- a/src/app/form/step1/page.tsx
+++ b/src/app/form/step1/page.tsx
@@ -2,7 +2,7 @@
 
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 
@@ -27,6 +27,7 @@ export default function Step1FormPage() {
     }
   };
 
+  // ローカルストレージから入力内容を復元
   useEffect(() => {
     const saved = localStorage.getItem('formStep1');
     if (saved) {
@@ -45,6 +46,7 @@ export default function Step1FormPage() {
   const fromPostalCode = watch("fromPostalCode");
   const toPostalCode = watch("toPostalCode");
 
+  // 郵便番号入力時に住所を自動取得
   useEffect(() => {
     const fetchAddress = async (zipcode: string, prefix: string) => {
       try {

--- a/src/app/form/step2/page.tsx
+++ b/src/app/form/step2/page.tsx
@@ -1,4 +1,5 @@
 // ✅ Step2: 荷物情報ページ
+// セクションは：家具・家電入力 / 段ボール目安 / 段ボール・ガムテープ準備 / その他備考
 
 'use client';
 
@@ -19,6 +20,7 @@ export default function Step2FormPage() {
     }
   };
 
+  // ローカルストレージに保存された入力内容を復元
   useEffect(() => {
     const saved = localStorage.getItem('formStep2');
     if (saved) {
@@ -32,6 +34,7 @@ export default function Step2FormPage() {
   const sectionStyle = "bg-white shadow-md rounded-lg p-6 border border-gray-200";
   const inputStyle = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm";
 
+  // 荷物カテゴリと選択肢
   const items = [
     {
       category: "ベッド",
@@ -153,6 +156,7 @@ export default function Step2FormPage() {
         <h1 className="text-3xl font-bold text-center text-blue-800">📦 荷物の数量を入力</h1>
         <p className="text-center text-sm text-gray-500">必要なものをすべて入力してください（0でもOK）</p>
 
+        {/* 家具・家電の数量入力 */}
         {items.map(({ category, data }) => (
           <section key={category} className={sectionStyle}>
             <h2 className="text-lg font-semibold mb-4">🗂 {category}</h2>
@@ -199,6 +203,7 @@ export default function Step2FormPage() {
           </section>
         ))}
 
+        {/* 段ボールの数の目安 */}
         <section className={sectionStyle}>
           <h2 className="text-lg font-semibold mb-4">📦 段ボール目安</h2>
           <p className="text-sm text-gray-500 mb-2">※おおまかな荷物量の目安として1つ選択してください</p>
@@ -223,6 +228,7 @@ export default function Step2FormPage() {
           </div>
         </section>
 
+        {/* 段ボールやガムテープの準備方法 */}
         <section className={sectionStyle}>
           <h2 className="text-lg font-semibold mb-4">📦 段ボール・ガムテープ準備</h2>
           <p className="text-sm text-gray-500 mb-2">※どちらかを選択してください</p>
@@ -249,6 +255,7 @@ export default function Step2FormPage() {
           </div>
         </section>
 
+        {/* その他の荷物に関する備考 */}
         <section className={sectionStyle}>
           <label className="flex-1 mr-4">📝 その他の荷物・補足があれば記入</label>
           <textarea rows={3} {...register("itemsRemarks")} className={inputStyle} placeholder="例：分解が必要なベッドあり、大型スピーカー×2など" />

--- a/src/app/form/step3/page.tsx
+++ b/src/app/form/step3/page.tsx
@@ -1,4 +1,5 @@
 // ✅ Step3: 作業オプション＋備考＋確認送信ページ
+// セクションは：作業オプション / 備考入力 / 最終確認
 
 'use client';
 
@@ -21,6 +22,7 @@ export default function Step3FormPage() {
     }
   };
   
+  // ローカルストレージから入力内容を復元
   useEffect(() => {
     const saved = localStorage.getItem('formStep3');
     if (saved) {
@@ -35,6 +37,7 @@ export default function Step3FormPage() {
   const labelStyle = "block text-sm font-medium text-gray-700 mb-1";
   const inputStyle = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm";
 
+  // 選択できる作業オプション
   const options = [
     "❄️ エアコン（本体＋室外機）取り外し",
     "🧺 洗濯機取り外し",


### PR DESCRIPTION
## Summary
- clean up unused import in step1 page
- document restoring data from localStorage and postal code lookup
- add section comments to step2
- document step3 sections and options

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685184275fd88332924468ebc6ee8f69