### PR TITLE
Add autosave to form

### DIFF
--- a/src/app/form/step1/page.tsx
+++ b/src/app/form/step1/page.tsx
@@ -46,6 +46,19 @@ export default function Step1FormPage() {
   const fromPostalCode = watch("fromPostalCode");
   const toPostalCode = watch("toPostalCode");
 
+  // 5秒ごとに現在の入力内容をローカルストレージへ保存
+  useEffect(() => {
+    const id = setInterval(() => {
+      try {
+        const data = watch();
+        localStorage.setItem('formStep1', JSON.stringify(data));
+      } catch (e) {
+        console.error('自動保存エラー:', e);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, [watch]);
+
   // 郵便番号入力時に住所を自動取得
   useEffect(() => {
     const fetchAddress = async (zipcode: string, prefix: string) => {

--- a/src/app/form/step2/page.tsx
+++ b/src/app/form/step2/page.tsx
@@ -34,6 +34,19 @@ export default function Step2FormPage() {
   const sectionStyle = "bg-white shadow-md rounded-lg p-6 border border-gray-200";
   const inputStyle = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm";
 
+  // 5秒ごとに現在の入力内容をローカルストレージへ保存
+  useEffect(() => {
+    const id = setInterval(() => {
+      try {
+        const data = watch();
+        localStorage.setItem('formStep2', JSON.stringify(data));
+      } catch (e) {
+        console.error('自動保存エラー:', e);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, [watch]);
+
   // 荷物カテゴリと選択肢
   const items = [
     {

--- a/src/app/form/step3/page.tsx
+++ b/src/app/form/step3/page.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 
 export default function Step3FormPage() {
-  const { register, handleSubmit,setValue } = useForm();
+  const { register, handleSubmit,setValue, watch } = useForm();
   const router = useRouter();
 
   const onSubmit = (data: any) => {
@@ -36,6 +36,19 @@ export default function Step3FormPage() {
   const sectionStyle = "bg-white shadow-md rounded-lg p-6 border border-gray-200";
   const labelStyle = "block text-sm font-medium text-gray-700 mb-1";
   const inputStyle = "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm";
+
+  // 5秒ごとに現在の入力内容をローカルストレージへ保存
+  useEffect(() => {
+    const id = setInterval(() => {
+      try {
+        const data = watch();
+        localStorage.setItem('formStep3', JSON.stringify(data));
+      } catch (e) {
+        console.error('自動保存エラー:', e);
+      }
+    }, 5000);
+    return () => clearInterval(id);
+  }, [watch]);
 
   // 選択できる作業オプション
   const options = [


### PR DESCRIPTION
## Summary
- autosave form inputs in step1 page
- autosave form inputs in step2 page
- autosave form inputs in step3 page

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685202f9f5988332aefce39abdad9053