### PR TITLE
Add auto katakana conversion

### DIFF
--- a/src/app/form/step1/page.tsx
+++ b/src/app/form/step1/page.tsx
@@ -5,6 +5,8 @@
 import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
+import Kuroshiro from 'kuroshiro';
+import KuromojiAnalyzer from 'kuroshiro-analyzer-kuromoji';
 
 export default function Step1FormPage() {
   const {
@@ -17,6 +19,16 @@ export default function Step1FormPage() {
 
   const router = useRouter();
   const [emailSuggestions, setEmailSuggestions] = useState<string[]>([]);
+  const [kuroshiro, setKuroshiro] = useState<Kuroshiro | null>(null);
+
+  useEffect(() => {
+    const init = async () => {
+      const k = new Kuroshiro();
+      await k.init(new KuromojiAnalyzer());
+      setKuroshiro(k);
+    };
+    init();
+  }, []);
   const commonDomains = [
     'gmail.com',
     'yahoo.co.jp',
@@ -71,6 +83,23 @@ export default function Step1FormPage() {
   const toOther = watch("toResidenceType") === "その他";
   const fromPostalCode = watch("fromPostalCode");
   const toPostalCode = watch("toPostalCode");
+  const lastName = watch('lastName');
+  const firstName = watch('firstName');
+
+  useEffect(() => {
+    const convertNames = async () => {
+      if (!kuroshiro) return;
+      if (lastName) {
+        const kana = await kuroshiro.convert(lastName, { to: 'katakana' });
+        setValue('lastNameKana', kana.replace(/\s/g, ''));
+      }
+      if (firstName) {
+        const kana = await kuroshiro.convert(firstName, { to: 'katakana' });
+        setValue('firstNameKana', kana.replace(/\s/g, ''));
+      }
+    };
+    convertNames();
+  }, [lastName, firstName, kuroshiro, setValue]);
 
   // 5秒ごとに現在の入力内容をローカルストレージへ保存
   useEffect(() => {


### PR DESCRIPTION
## Summary
- automatically convert kanji names to katakana

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68521302b8b88332a0015a9384c93cbf