### PR TITLE
Fix date/time validation

### DIFF
--- a/src/app/form/step1/page.tsx
+++ b/src/app/form/step1/page.tsx
@@ -318,7 +318,10 @@ export default function Step1FormPage() {
                       type="date"
                       min={(() => {
                         const today = new Date();
-                        return today.toISOString().split("T")[0];
+                        const offsetMs = today.getTimezoneOffset() * 60000;
+                        return new Date(today.getTime() - offsetMs)
+                          .toISOString()
+                          .split("T")[0];
                       })()}
                       {...register(`date${n}`, {
                         required: isRequired
@@ -336,6 +339,14 @@ export default function Step1FormPage() {
                     </label>
                     <select
                       {...register(`timeSlot${n}`, { required: isRequired })}
+                      onChange={(e) => {
+                        const date = watch(`date${n}`);
+                        if (!date && e.target.value) {
+                          alert(`第${n}希望日を先に選択してください`);
+                          e.target.value = '';
+                        }
+                        register(`timeSlot${n}`, { required: isRequired }).onChange(e);
+                      }}
                       className={timeSelectClass}
                     >
                       <option value=""></option>


### PR DESCRIPTION
## Summary
- ensure date input min uses local time zone
- alert when selecting time without a date

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acbbb217483329a3812e668f8d3e1