### PR TITLE
Fix currency expressions causing build error

### DIFF
--- a/src/app/admin/contracts/page.tsx
+++ b/src/app/admin/contracts/page.tsx
@@ -236,7 +236,7 @@ export default function AdminContracts() {
                             月別売上
                           </dt>
                           <dd className="text-lg font-medium text-gray-900">
-                            ¥{getCurrentMonthSummary().totalRevenue.toLocaleString()}
+                            {'¥' + getCurrentMonthSummary().totalRevenue.toLocaleString()}
                           </dd>
                         </dl>
                       </div>
@@ -280,7 +280,7 @@ export default function AdminContracts() {
                             総成約金額
                           </dt>
                           <dd className="text-lg font-medium text-gray-900">
-                            ¥{getCurrentMonthSummary().totalAmount.toLocaleString()}
+                            {'¥' + getCurrentMonthSummary().totalAmount.toLocaleString()}
                           </dd>
                         </dl>
                       </div>
@@ -302,9 +302,15 @@ export default function AdminContracts() {
                             平均成約金額
                           </dt>
                           <dd className="text-lg font-medium text-gray-900">
-                            ¥{getCurrentMonthSummary().totalContracts > 0
-                              ? Math.round(getCurrentMonthSummary().totalAmount / getCurrentMonthSummary().totalContracts).toLocaleString()
-                              : '0'}
+                            {
+                              '¥' +
+                              (getCurrentMonthSummary().totalContracts > 0
+                                ? Math.round(
+                                    getCurrentMonthSummary().totalAmount /
+                                      getCurrentMonthSummary().totalContracts
+                                  ).toLocaleString()
+                                : '0')
+                            }
                           </dd>
                         </dl>
                       </div>
@@ -447,13 +453,13 @@ export default function AdminContracts() {
                             {new Date(contract.moveDate).toLocaleDateString('ja-JP')}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            ¥{contract.contractAmount.toLocaleString()}
+                            {'¥' + contract.contractAmount.toLocaleString()}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-red-600">
-                            ¥{contract.commission.toLocaleString()}
+                            {'¥' + contract.commission.toLocaleString()}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-green-600">
-                            ¥{contract.revenue.toLocaleString()}
+                            {'¥' + contract.revenue.toLocaleString()}
                           </td>
                         </tr>
                       ))}

--- a/src/app/admin/quotes/page.tsx
+++ b/src/app/admin/quotes/page.tsx
@@ -291,7 +291,7 @@ export default function AdminQuotes() {
                             {quote.responseDate ? new Date(quote.responseDate).toLocaleDateString('ja-JP') : '-'}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
-                            ¥{quote.amount.toLocaleString()}
+                            {'¥' + quote.amount.toLocaleString()}
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
                             {getStatusBadge(quote.status)}

--- a/src/app/pricing/step2/page.tsx
+++ b/src/app/pricing/step2/page.tsx
@@ -278,7 +278,7 @@ export default function PricingStep2Page() {
                         />
                       </td>
                       <td className="border border-gray-200 px-4 py-2 font-semibold text-blue-600">
-                        ¥{calculateTotalPrice(rule).toLocaleString()}
+                        {'¥' + calculateTotalPrice(rule).toLocaleString()}
                       </td>
                       <td className="border border-gray-200 px-4 py-2">
                         <button

--- a/src/app/pricing/step3/page.tsx
+++ b/src/app/pricing/step3/page.tsx
@@ -280,13 +280,13 @@ export default function PricingStep3Page() {
                   {/* 表示例 */}
                   <div className="mt-2 text-sm text-gray-600">
                     {rule.min !== null && rule.max !== null && (
-                      <span>{rule.min}km〜{rule.max}km → +¥{rule.price.toLocaleString()}</span>
+                      <span>{rule.min}km〜{rule.max}km → {'+¥' + rule.price.toLocaleString()}</span>
                     )}
                     {rule.min !== null && rule.max === null && (
-                      <span>{rule.min}km以上 → +¥{rule.price.toLocaleString()}</span>
+                      <span>{rule.min}km以上 → {'+¥' + rule.price.toLocaleString()}</span>
                     )}
                     {rule.min === null && rule.max !== null && (
-                      <span>{rule.max}km以下 → +¥{rule.price.toLocaleString()}</span>
+                      <span>{rule.max}km以下 → {'+¥' + rule.price.toLocaleString()}</span>
                     )}
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- correct yen currency formatting across admin pages

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869e26765a88332b9658bdbe7a5f95e