### PR TITLE
Update dashboard back labels

### DIFF
--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -168,7 +168,7 @@ export default function AdminNotifications() {
                 onClick={() => router.push('/admin/dashboard')}
                 className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm font-medium"
               >
-                トップページに戻る
+                トップに戻る
               </button>
             </div>
           </div>

--- a/src/app/admin/profile/page.tsx
+++ b/src/app/admin/profile/page.tsx
@@ -196,7 +196,7 @@ export default function AdminProfile() {
                 onClick={() => router.push('/admin/dashboard')}
                 className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm font-medium"
               >
-                トップページに戻る
+                トップに戻る
               </button>
             </div>
           </div>

--- a/src/app/admin/quotes/page.tsx
+++ b/src/app/admin/quotes/page.tsx
@@ -173,7 +173,7 @@ export default function AdminQuotes() {
                 onClick={() => router.push('/admin/dashboard')}
                 className="bg-gray-600 hover:bg-gray-700 text-white px-4 py-2 rounded-md text-sm font-medium"
               >
-                トップページに戻る
+                トップに戻る
               </button>
             </div>
           </div>

--- a/src/app/admin/register/page.tsx
+++ b/src/app/admin/register/page.tsx
@@ -299,7 +299,7 @@ export default function AdminRegister() {
 
           <div className="mt-6 text-center">
             <Link href="/" className="text-blue-600 hover:text-blue-500 text-sm">
-              ← トップページに戻る
+              ← トップに戻る
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- use "トップに戻る" for admin back buttons

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869eceb33f88332838d1b78c9b7bb4d