### PR TITLE
Fix unclosed div in admin contracts page

### DIFF
--- a/src/app/admin/contracts/page.tsx
+++ b/src/app/admin/contracts/page.tsx
@@ -475,6 +475,7 @@ export default function AdminContracts() {
               </div>
             </div>
           </div>
+          </div>
         </main>
       </div>
     </AdminAuthGuard>


### PR DESCRIPTION
## Summary
- close missing `<div>` before the main closing tag

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869fd93e8fc83328d00aa456fbfa584