### PR TITLE
Fix pricing step2 layout

### DIFF
--- a/src/app/pricing/step2/page.tsx
+++ b/src/app/pricing/step2/page.tsx
@@ -1,7 +1,7 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 
 // トラック種別の定義
 const TRUCK_TYPES = [
@@ -11,14 +11,14 @@ const TRUCK_TYPES = [
   "3t",
   "4t",
   "4t複数",
-  "特別対応"
+  "特別対応",
 ];
 
 // 作業人数の定義
 const WORKER_COUNTS = [1, 2, 3, 4, 5, 6];
 
-// ポイント範囲の定義（1～9999、1刻みで詳細設定可能）
-const POINT_RANGE = Array.from({ length: 9999 }, (_, i) => i + 1);
+// ポイント範囲の定義（1～1000、1刻み）
+const POINT_RANGE = Array.from({ length: 1000 }, (_, i) => i + 1);
 
 // 初期データ
 const DEFAULT_PRICING = [
@@ -41,12 +41,12 @@ interface PricingRule {
 
 // オプション型
 const OPTION_TYPES = [
-  { value: 'free', label: '無料オプション', color: 'text-green-600' },
-  { value: 'paid', label: '定額オプション', color: 'text-blue-600' },
-  { value: 'individual', label: '個別見積もり', color: 'text-blue-600' },
-  { value: 'nonSupported', label: '対応不可', color: 'text-red-600' },
+  { value: "free", label: "無料オプション", color: "text-green-600" },
+  { value: "paid", label: "定額オプション", color: "text-blue-600" },
+  { value: "individual", label: "個別見積もり", color: "text-blue-600" },
+  { value: "nonSupported", label: "対応不可", color: "text-red-600" },
 ] as const;
-type OptionType = typeof OPTION_TYPES[number]['value'];
+type OptionType = (typeof OPTION_TYPES)[number]["value"];
 interface OptionItem {
   id: string;
   label: string;
@@ -55,18 +55,46 @@ interface OptionItem {
   isDefault?: boolean;
   unit?: string;
   remarks?: string; // Added missing property
-  minPoint?: number;
-  maxPoint?: number;
 }
 const DEFAULT_OPTIONS: OptionItem[] = [
-  { id: 'opt-1', label: '🏠 建物養生（壁や床の保護）', type: 'free', isDefault: true },
-  { id: 'opt-2', label: '📦 荷造り・荷ほどきの代行', type: 'free', isDefault: true },
-  { id: 'opt-3', label: '🪑 家具・家電の分解・組み立て', type: 'free', isDefault: true },
-  { id: 'opt-4', label: '🧺 洗濯機取り外し', type: 'free', isDefault: true },
-  { id: 'opt-5', label: '❄️ エアコン（本体＋室外機）取り外し', type: 'free', isDefault: true },
-  { id: 'opt-6', label: '💡 照明・テレビ配線取り外し', type: 'free', isDefault: true },
-  { id: 'opt-7', label: '🚮 不用品の回収・廃棄', type: 'free', isDefault: true },
-  { id: 'opt-8', label: '🐾 ペット運搬', type: 'free', isDefault: true },
+  {
+    id: "opt-1",
+    label: "🏠 建物養生（壁や床の保護）",
+    type: "free",
+    isDefault: true,
+  },
+  {
+    id: "opt-2",
+    label: "📦 荷造り・荷ほどきの代行",
+    type: "free",
+    isDefault: true,
+  },
+  {
+    id: "opt-3",
+    label: "🪑 家具・家電の分解・組み立て",
+    type: "free",
+    isDefault: true,
+  },
+  { id: "opt-4", label: "🧺 洗濯機取り外し", type: "free", isDefault: true },
+  {
+    id: "opt-5",
+    label: "❄️ エアコン（本体＋室外機）取り外し",
+    type: "free",
+    isDefault: true,
+  },
+  {
+    id: "opt-6",
+    label: "💡 照明・テレビ配線取り外し",
+    type: "free",
+    isDefault: true,
+  },
+  {
+    id: "opt-7",
+    label: "🚮 不用品の回収・廃棄",
+    type: "free",
+    isDefault: true,
+  },
+  { id: "opt-8", label: "🐾 ペット運搬", type: "free", isDefault: true },
 ];
 
 export default function PricingStep1Page() {
@@ -74,29 +102,35 @@ export default function PricingStep1Page() {
   const [pricingRules, setPricingRules] = useState<PricingRule[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [options, setOptions] = useState<OptionItem[]>(DEFAULT_OPTIONS);
-  const [newOptionLabel, setNewOptionLabel] = useState('');
-  const [newOptionType, setNewOptionType] = useState<OptionType>('free');
+  const [newOptionLabel, setNewOptionLabel] = useState("");
+  const [newOptionType, setNewOptionType] = useState<OptionType>("free");
   const [newOptionPrice, setNewOptionPrice] = useState<number>(0);
-  const [newOptionUnit, setNewOptionUnit] = useState<string>('');
-  const [newOptionMinPoint, setNewOptionMinPoint] = useState<number | undefined>(undefined);
-  const [newOptionMaxPoint, setNewOptionMaxPoint] = useState<number | undefined>(undefined);
-  const [optionErrors, setOptionErrors] = useState<{ [optionId: string]: string }>({});
-  const [optionAddError, setOptionAddError] = useState('');
-  const [newPricingMaxPoint, setNewPricingMaxPoint] = useState<number | undefined>(undefined);
-  const [newPricingPrice, setNewPricingPrice] = useState<number | undefined>(undefined);
-  
+  const [newOptionUnit, setNewOptionUnit] = useState<string>("");
+  const [optionErrors, setOptionErrors] = useState<{
+    [optionId: string]: string;
+  }>({});
+  const [optionAddError, setOptionAddError] = useState("");
+  const [newPricingMaxPoint, setNewPricingMaxPoint] = useState<
+    number | undefined
+  >(undefined);
+  const [newPricingPrice, setNewPricingPrice] = useState<number | undefined>(
+    undefined,
+  );
+
   // ソート用のstate
-  const [sortField, setSortField] = useState<'truckType' | 'minPoint' | 'maxPoint' | 'price'>('minPoint');
-  const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
+  const [sortField, setSortField] = useState<
+    "truckType" | "minPoint" | "maxPoint" | "price"
+  >("minPoint");
+  const [sortDirection, setSortDirection] = useState<"asc" | "desc">("asc");
 
   // 料金設定追加用state
-  const [newTruckType, setNewTruckType] = useState<string>('');
+  const [newTruckType, setNewTruckType] = useState<string>("");
   const [pricingErrors, setPricingErrors] = useState<string[]>([]);
   const [rowErrorIds, setRowErrorIds] = useState<Set<string>>(new Set());
 
   // 初期データの読み込み
   useEffect(() => {
-    const savedPricing = localStorage.getItem('pricingStep1');
+    const savedPricing = localStorage.getItem("pricingStep1");
     if (savedPricing) {
       setPricingRules(JSON.parse(savedPricing));
     } else {
@@ -106,7 +140,7 @@ export default function PricingStep1Page() {
         truckType: rule.truckType,
         minPoint: rule.minPoint,
         maxPoint: rule.maxPoint,
-        price: rule.price
+        price: rule.price,
       }));
       setPricingRules(defaultPricing);
     }
@@ -116,14 +150,14 @@ export default function PricingStep1Page() {
   // 自動保存
   useEffect(() => {
     if (!isLoading) {
-      localStorage.setItem('pricingStep1', JSON.stringify(pricingRules));
+      localStorage.setItem("pricingStep1", JSON.stringify(pricingRules));
     }
   }, [pricingRules, isLoading]);
 
   // オプション自動保存
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      const saved = localStorage.getItem('optionPricingStep1');
+    if (typeof window !== "undefined") {
+      const saved = localStorage.getItem("optionPricingStep1");
       if (saved) {
         setOptions(JSON.parse(saved));
       }
@@ -133,17 +167,20 @@ export default function PricingStep1Page() {
   // 料金ルールの追加
   const addPricingRule = () => {
     let errors: string[] = [];
-    if (!newTruckType) errors.push('トラック種別を選択してください');
-    if (newPricingMaxPoint === undefined) errors.push('ポイント最大値は必須です');
-    if (newPricingPrice === undefined) errors.push('料金は必須です');
+    if (!newTruckType) errors.push("トラック種別を選択してください");
+    if (newPricingMaxPoint === undefined)
+      errors.push("ポイント最大値は必須です");
+    if (newPricingPrice === undefined) errors.push("料金は必須です");
     const lastRule = pricingRules[pricingRules.length - 1];
-    const newMinPoint = lastRule && lastRule.maxPoint !== undefined ? lastRule.maxPoint + 1 : 1;
-    if (newPricingMaxPoint !== undefined && newPricingMaxPoint <= newMinPoint) errors.push('最大値は前の行の最大値より大きい値を選択してください');
+    const newMinPoint =
+      lastRule && lastRule.maxPoint !== undefined ? lastRule.maxPoint + 1 : 1;
+    if (newPricingMaxPoint !== undefined && newPricingMaxPoint <= newMinPoint)
+      errors.push("最大値は前の行の最大値より大きい値を選択してください");
     if (errors.length > 0) {
       setPricingErrors(errors);
       return;
     }
-    setPricingRules(prev => [
+    setPricingRules((prev) => [
       ...prev,
       {
         id: `pricing-${Date.now()}`,
@@ -151,9 +188,9 @@ export default function PricingStep1Page() {
         minPoint: newMinPoint,
         maxPoint: newPricingMaxPoint,
         price: newPricingPrice,
-      }
+      },
     ]);
-    setNewTruckType('');
+    setNewTruckType("");
     setNewPricingMaxPoint(undefined);
     setNewPricingPrice(undefined);
     setPricingErrors([]);
@@ -162,41 +199,52 @@ export default function PricingStep1Page() {
   // 料金ルールの削除
   const removePricingRule = (id: string) => {
     if (pricingRules.length <= 1) {
-      setOptionAddError('最低1行は必要です');
+      setOptionAddError("最低1行は必要です");
       return;
     }
-    setPricingRules(pricingRules.filter(rule => rule.id !== id));
-    setOptionAddError('');
+    setPricingRules(pricingRules.filter((rule) => rule.id !== id));
+    setOptionAddError("");
   };
 
   // 料金ルールの更新
-  const updatePricingRule = (id: string, field: keyof PricingRule, value: any) => {
-    setPricingRules(pricingRules.map(rule =>
-      rule.id === id ? { ...rule, [field]: value } : rule
-    ));
+  const updatePricingRule = (
+    id: string,
+    field: keyof PricingRule,
+    value: any,
+  ) => {
+    setPricingRules(
+      pricingRules.map((rule) =>
+        rule.id === id ? { ...rule, [field]: value } : rule,
+      ),
+    );
   };
 
   // 最大値更新時の最小値自動調整
   const updateMaxPoint = (id: string, newMaxPoint: number) => {
-    const ruleIndex = pricingRules.findIndex(rule => rule.id === id);
+    const ruleIndex = pricingRules.findIndex((rule) => rule.id === id);
     if (ruleIndex === -1) return;
-    
+
     const rule = pricingRules[ruleIndex];
     const prevRule = ruleIndex > 0 ? pricingRules[ruleIndex - 1] : null;
-    
+
     // 新しい最小値を計算
-    const newMinPoint = prevRule && prevRule.maxPoint !== undefined ? prevRule.maxPoint + 1 : 1;
-    
+    const newMinPoint =
+      prevRule && prevRule.maxPoint !== undefined ? prevRule.maxPoint + 1 : 1;
+
     // 最大値の妥当性チェック
     if (newMaxPoint <= newMinPoint) {
-      setOptionAddError('最大値は前の行の最大値より大きい値を選択してください');
+      setOptionAddError("最大値は前の行の最大値より大きい値を選択してください");
       return;
     }
-    
+
     // 次の行の最小値も調整
     const updatedRules = [...pricingRules];
-    updatedRules[ruleIndex] = { ...rule, minPoint: newMinPoint, maxPoint: newMaxPoint };
-    
+    updatedRules[ruleIndex] = {
+      ...rule,
+      minPoint: newMinPoint,
+      maxPoint: newMaxPoint,
+    };
+
     // 後続の行の最小値を再計算
     for (let i = ruleIndex + 1; i < updatedRules.length; i++) {
       const currentRule = updatedRules[i];
@@ -205,9 +253,9 @@ export default function PricingStep1Page() {
         updatedRules[i] = { ...currentRule, minPoint: prevRule.maxPoint + 1 };
       }
     }
-    
+
     setPricingRules(updatedRules);
-    setOptionAddError('');
+    setOptionAddError("");
   };
 
   // 料金計算
@@ -216,11 +264,15 @@ export default function PricingStep1Page() {
   };
 
   // validatePricingのエラーを画面上部に表示、エラー行は赤枠
-  const validatePricing = (): { isValid: boolean; errors: string[]; errorIds: Set<string> } => {
+  const validatePricing = (): {
+    isValid: boolean;
+    errors: string[];
+    errorIds: Set<string>;
+  } => {
     const errors: string[] = [];
     const errorIds = new Set<string>();
     if (pricingRules.length === 0) {
-      errors.push('最低1つの料金設定が必要です');
+      errors.push("最低1つの料金設定が必要です");
       return { isValid: false, errors, errorIds };
     }
     const combinations = new Set();
@@ -228,26 +280,33 @@ export default function PricingStep1Page() {
       const rule = pricingRules[i];
       const key = `${rule.truckType}-${rule.minPoint}-${rule.maxPoint}`;
       if (combinations.has(key)) {
-        errors.push(`重複: ${rule.truckType} × ${rule.minPoint} - ${rule.maxPoint}の設定が重複しています`);
+        errors.push(
+          `重複: ${rule.truckType} × ${rule.minPoint} - ${rule.maxPoint}の設定が重複しています`,
+        );
         errorIds.add(rule.id);
       } else {
         combinations.add(key);
       }
       if (!rule.truckType) {
-        errors.push(`行${i+1}: トラック種別を選択してください`);
+        errors.push(`行${i + 1}: トラック種別を選択してください`);
         errorIds.add(rule.id);
       }
       if (rule.price === undefined || rule.price < 0) {
-        errors.push(`行${i+1}: 料金は0円以上で入力してください`);
+        errors.push(`行${i + 1}: 料金は0円以上で入力してください`);
         errorIds.add(rule.id);
       }
     }
     for (let i = 0; i < pricingRules.length - 1; i++) {
       const currentRule = pricingRules[i];
       const nextRule = pricingRules[i + 1];
-      if (currentRule.maxPoint !== undefined && nextRule.minPoint !== undefined) {
+      if (
+        currentRule.maxPoint !== undefined &&
+        nextRule.minPoint !== undefined
+      ) {
         if (currentRule.maxPoint + 1 !== nextRule.minPoint) {
-          errors.push(`ポイント範囲の連続性エラー: ${currentRule.truckType}(${currentRule.minPoint}-${currentRule.maxPoint}) と ${nextRule.truckType}(${nextRule.minPoint}-${nextRule.maxPoint}) の間が連続していません`);
+          errors.push(
+            `ポイント範囲の連続性エラー: ${currentRule.truckType}(${currentRule.minPoint}-${currentRule.maxPoint}) と ${nextRule.truckType}(${nextRule.minPoint}-${nextRule.maxPoint}) の間が連続していません`,
+          );
           errorIds.add(currentRule.id);
           errorIds.add(nextRule.id);
         }
@@ -257,87 +316,99 @@ export default function PricingStep1Page() {
   };
 
   // 追加フォームのバリデーション
-  const isAddOptionMinMaxError =
-    newOptionMinPoint === undefined || newOptionMaxPoint === undefined || newOptionMinPoint >= newOptionMaxPoint;
 
   // オプション追加
   const handleAddOption = () => {
     if (!newOptionLabel.trim()) {
-      setOptionAddError('オプション名は必須です');
+      setOptionAddError("オプション名は必須です");
       return;
     }
-    if (newOptionType === 'paid' && (!newOptionPrice || newOptionPrice < 0)) {
-      setOptionAddError('有料オプションは金額を0円以上で入力してください');
+    if (newOptionType === "paid" && (!newOptionPrice || newOptionPrice < 0)) {
+      setOptionAddError("有料オプションは金額を0円以上で入力してください");
       return;
     }
-    if (newOptionMinPoint === undefined || newOptionMaxPoint === undefined) {
-      setOptionAddError('ポイント最小値・最大値は必須です');
-      return;
-    }
-    if (newOptionMinPoint >= newOptionMaxPoint) {
-      setOptionAddError('最大値は最小値より大きい値を入力してください');
-      return;
-    }
-    setOptions(prev => [
+    setOptions((prev) => [
       ...prev,
       {
         id: `opt-${Date.now()}`,
         label: newOptionLabel.trim(),
         type: newOptionType,
-        price: newOptionType === 'paid' ? newOptionPrice : undefined,
+        price: newOptionType === "paid" ? newOptionPrice : undefined,
         isDefault: false,
-        unit: newOptionUnit,
-        minPoint: newOptionMinPoint,
-        maxPoint: newOptionMaxPoint,
-      }
+        unit: newOptionType === "paid" ? newOptionUnit : undefined,
+      },
     ]);
-    setNewOptionLabel('');
-    setNewOptionType('free');
+    setNewOptionLabel("");
+    setNewOptionType("free");
     setNewOptionPrice(0);
-    setNewOptionUnit('');
-    setNewOptionMinPoint(undefined);
-    setNewOptionMaxPoint(undefined);
-    setOptionAddError('');
+    setNewOptionUnit("");
+    setOptionAddError("");
   };
 
   // オプション削除
   const handleDeleteOption = (id: string) => {
-    setOptions(prev => prev.filter(opt => opt.id !== id));
+    setOptions((prev) => prev.filter((opt) => opt.id !== id));
   };
 
   // オプション種別変更
   const handleOptionTypeChange = (id: string, type: OptionType) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, type, price: type === 'paid' ? (opt.price || 0) : undefined } : opt));
+    const current = options.find((o) => o.id === id);
+    setOptions((prev) =>
+      prev.map((opt) => {
+        if (opt.id !== id) return opt;
+        const updated: OptionItem = { ...opt, type };
+        if (type === "paid") {
+          updated.price = opt.price ?? 0;
+        } else {
+          updated.price = undefined;
+          updated.unit = undefined;
+        }
+        return updated;
+      }),
+    );
+    if (type === "nonSupported") {
+      setOptionErrors((prev) => ({
+        ...prev,
+        [id]: current && current.remarks ? "" : "備考は必須です",
+      }));
+    } else {
+      setOptionErrors((prev) => ({ ...prev, [id]: "" }));
+    }
   };
 
   // オプション名変更
   const handleOptionLabelChange = (id: string, label: string) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, label } : opt));
+    setOptions((prev) =>
+      prev.map((opt) => (opt.id === id ? { ...opt, label } : opt)),
+    );
   };
 
   // オプション金額変更
   const handleOptionPriceChange = (id: string, price: number) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, price } : opt));
+    setOptions((prev) =>
+      prev.map((opt) => (opt.id === id ? { ...opt, price } : opt)),
+    );
   };
 
   // オプション単位変更
   const handleOptionUnitChange = (id: string, unit: string) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, unit } : opt));
+    setOptions((prev) =>
+      prev.map((opt) => (opt.id === id ? { ...opt, unit } : opt)),
+    );
   };
 
   // オプション備考変更
   const handleOptionRemarksChange = (id: string, remarks: string) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, remarks } : opt));
-  };
-
-  // オプション最大値変更
-  const handleOptionMaxPointChange = (id: string, maxPoint: number) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, maxPoint } : opt));
-  };
-
-  // オプション最小値変更
-  const handleOptionMinPointChange = (id: string, minPoint: number) => {
-    setOptions(prev => prev.map(opt => opt.id === id ? { ...opt, minPoint } : opt));
+    setOptions((prev) =>
+      prev.map((opt) => (opt.id === id ? { ...opt, remarks } : opt)),
+    );
+    const option = options.find((o) => o.id === id);
+    if (option && option.type === "nonSupported") {
+      setOptionErrors((prev) => ({
+        ...prev,
+        [id]: remarks.trim() ? "" : "備考は必須です",
+      }));
+    }
   };
 
   // ソート機能
@@ -345,40 +416,44 @@ export default function PricingStep1Page() {
     return [...rules].sort((a, b) => {
       let aValue: any = a[sortField];
       let bValue: any = b[sortField];
-      
+
       // undefinedの場合は最後に配置
       if (aValue === undefined && bValue === undefined) return 0;
       if (aValue === undefined) return 1;
       if (bValue === undefined) return -1;
-      
+
       // 数値の場合は数値として比較
-      if (typeof aValue === 'number' && typeof bValue === 'number') {
-        return sortDirection === 'asc' ? aValue - bValue : bValue - aValue;
+      if (typeof aValue === "number" && typeof bValue === "number") {
+        return sortDirection === "asc" ? aValue - bValue : bValue - aValue;
       }
-      
+
       // 文字列の場合は文字列として比較
-      if (typeof aValue === 'string' && typeof bValue === 'string') {
-        return sortDirection === 'asc' 
-          ? aValue.localeCompare(bValue) 
+      if (typeof aValue === "string" && typeof bValue === "string") {
+        return sortDirection === "asc"
+          ? aValue.localeCompare(bValue)
           : bValue.localeCompare(aValue);
       }
-      
+
       return 0;
     });
   };
 
-  const handleSort = (field: 'truckType' | 'minPoint' | 'maxPoint' | 'price') => {
+  const handleSort = (
+    field: "truckType" | "minPoint" | "maxPoint" | "price",
+  ) => {
     if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
       setSortField(field);
-      setSortDirection('asc');
+      setSortDirection("asc");
     }
   };
 
-  const getSortIcon = (field: 'truckType' | 'minPoint' | 'maxPoint' | 'price') => {
-    if (sortField !== field) return '↕️';
-    return sortDirection === 'asc' ? '↑' : '↓';
+  const getSortIcon = (
+    field: "truckType" | "minPoint" | "maxPoint" | "price",
+  ) => {
+    if (sortField !== field) return "↕️";
+    return sortDirection === "asc" ? "↑" : "↓";
   };
 
   // handleNextでバリデーションエラーを画面上部に表示
@@ -387,12 +462,12 @@ export default function PricingStep1Page() {
     setPricingErrors(validation.errors);
     setRowErrorIds(validation.errorIds);
     if (!validation.isValid) return;
-    router.push('/pricing/step3');
+    router.push("/pricing/step3");
   };
 
   // 前へ戻る
   const handleBack = () => {
-    router.push('/pricing/step1');
+    router.push("/pricing/step1");
   };
 
   if (isLoading) {
@@ -408,27 +483,33 @@ export default function PricingStep1Page() {
       <div className="max-w-6xl mx-auto">
         {/* ヘッダー */}
         <div className="text-center mb-8">
-          <h1 className="text-3xl font-bold text-blue-800 mb-4">
-            💰 料金設定
-          </h1>
+          <h1 className="text-3xl font-bold text-blue-800 mb-4">💰 料金設定</h1>
           <div className="flex justify-center items-center space-x-4 text-sm text-gray-600">
             <div className="flex items-center">
-              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">1</div>
+              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">
+                1
+              </div>
               <span className="ml-2">ポイント設定</span>
             </div>
             <div className="w-8 h-1 bg-gray-300"></div>
             <div className="flex items-center">
-              <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold">2</div>
+              <div className="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center font-bold">
+                2
+              </div>
               <span className="ml-2">料金設定</span>
             </div>
             <div className="w-8 h-1 bg-gray-300"></div>
             <div className="flex items-center">
-              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">3</div>
+              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">
+                3
+              </div>
               <span className="ml-2">距離加算</span>
             </div>
             <div className="w-8 h-1 bg-gray-300"></div>
             <div className="flex items-center">
-              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">4</div>
+              <div className="w-8 h-8 bg-gray-300 text-gray-600 rounded-full flex items-center justify-center font-bold">
+                4
+              </div>
               <span className="ml-2">シーズン設定</span>
             </div>
           </div>
@@ -436,7 +517,9 @@ export default function PricingStep1Page() {
 
         {/* 説明 */}
         <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
-          <h2 className="text-lg font-semibold text-blue-800 mb-2">📋 設定内容</h2>
+          <h2 className="text-lg font-semibold text-blue-800 mb-2">
+            📋 設定内容
+          </h2>
           <p className="text-gray-700">
             トラック種別とポイント範囲に応じた料金を設定します。
             ポイント最小値は自動設定され、最大値のみ選択できます。各設定は連続したポイント範囲で管理されます。
@@ -445,45 +528,59 @@ export default function PricingStep1Page() {
 
         {/* 料金設定 */}
         <div className="bg-white shadow-md rounded-lg p-6">
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-xl font-semibold text-gray-800">💰 料金設定</h2>
-            <button
-              onClick={addPricingRule}
-              className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded transition"
-            >
-              ＋ 料金設定追加
-            </button>
-          </div>
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            💰 料金設定
+          </h2>
 
           {/* 料金設定追加フォーム */}
           <div className="flex flex-wrap gap-2 mb-4 items-end bg-blue-50 p-4 rounded">
             <select
               value={newTruckType}
-              onChange={e => setNewTruckType(e.target.value)}
+              onChange={(e) => setNewTruckType(e.target.value)}
               className="border rounded px-2 py-1 min-w-[120px]"
             >
               <option value="">トラック種別を選択</option>
-              {TRUCK_TYPES.map(type => (
-                <option key={type} value={type}>{type}</option>
+              {TRUCK_TYPES.map((type) => (
+                <option key={type} value={type}>
+                  {type}
+                </option>
               ))}
             </select>
-            <span className="text-gray-600 text-sm bg-gray-100 px-2 py-1 rounded">{pricingRules.length > 0 ? (pricingRules[pricingRules.length-1].maxPoint!+1) : 1}</span>
+            <span className="text-gray-600 text-sm bg-gray-100 px-2 py-1 rounded">
+              {pricingRules.length > 0
+                ? pricingRules[pricingRules.length - 1].maxPoint! + 1
+                : 1}
+            </span>
             <span className="text-gray-500">～</span>
             <select
-              value={newPricingMaxPoint ?? ''}
-              onChange={e => setNewPricingMaxPoint(e.target.value ? parseInt(e.target.value) : undefined)}
+              value={newPricingMaxPoint ?? ""}
+              onChange={(e) =>
+                setNewPricingMaxPoint(
+                  e.target.value ? parseInt(e.target.value) : undefined,
+                )
+              }
               className="border rounded px-2 py-1 min-w-[80px]"
             >
               <option value="">最大値</option>
-              {POINT_RANGE.filter(point => pricingRules.length === 0 || point > pricingRules[pricingRules.length-1].maxPoint!).map(point => (
-                <option key={point} value={point}>{point}</option>
+              {POINT_RANGE.filter(
+                (point) =>
+                  pricingRules.length === 0 ||
+                  point > pricingRules[pricingRules.length - 1].maxPoint!,
+              ).map((point) => (
+                <option key={point} value={point}>
+                  {point}
+                </option>
               ))}
             </select>
             <input
               type="number"
               min="0"
-              value={newPricingPrice ?? ''}
-              onChange={e => setNewPricingPrice(e.target.value ? parseInt(e.target.value) : undefined)}
+              value={newPricingPrice ?? ""}
+              onChange={(e) =>
+                setNewPricingPrice(
+                  e.target.value ? parseInt(e.target.value) : undefined,
+                )
+              }
               className="border rounded px-2 py-1 min-w-[80px]"
               placeholder="料金"
             />
@@ -491,82 +588,113 @@ export default function PricingStep1Page() {
               type="button"
               onClick={addPricingRule}
               className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded transition"
-            >追加</button>
+            >
+              追加
+            </button>
           </div>
           {pricingErrors.length > 0 && (
             <div className="bg-red-50 border border-red-300 text-red-700 rounded p-2 mb-4">
               <ul className="list-disc pl-5">
-                {pricingErrors.map((err, i) => <li key={i}>{err}</li>)}
+                {pricingErrors.map((err, i) => (
+                  <li key={i}>{err}</li>
+                ))}
               </ul>
             </div>
           )}
 
           {pricingRules.length === 0 ? (
             <div className="text-center py-8 text-gray-500">
-              料金設定がありません。上記の「＋ 料金設定追加」ボタンで追加してください。
+              料金設定がありません。下のフォームから追加してください。
             </div>
           ) : (
             <div className="overflow-x-auto">
               <table className="w-full border-collapse">
                 <thead>
                   <tr className="bg-gray-50">
-                    <th 
+                    <th
                       className="border border-gray-200 px-4 py-2 text-left cursor-pointer hover:bg-gray-100"
-                      onClick={() => handleSort('truckType')}
+                      onClick={() => handleSort("truckType")}
                     >
                       <div className="flex items-center justify-between">
                         トラック種別
-                        <span className="text-xs">{getSortIcon('truckType')}</span>
+                        <span className="text-xs">
+                          {getSortIcon("truckType")}
+                        </span>
                       </div>
                     </th>
-                    <th 
+                    <th
                       className="border border-gray-200 px-4 py-2 text-left cursor-pointer hover:bg-gray-100"
-                      onClick={() => handleSort('minPoint')}
+                      onClick={() => handleSort("minPoint")}
                     >
                       <div className="flex items-center justify-between">
                         ポイント範囲
-                        <span className="text-xs">{getSortIcon('minPoint')}</span>
+                        <span className="text-xs">
+                          {getSortIcon("minPoint")}
+                        </span>
                       </div>
                     </th>
-                    <th 
+                    <th
                       className="border border-gray-200 px-4 py-2 text-left cursor-pointer hover:bg-gray-100"
-                      onClick={() => handleSort('price')}
+                      onClick={() => handleSort("price")}
                     >
                       <div className="flex items-center justify-between">
                         料金
-                        <span className="text-xs">{getSortIcon('price')}</span>
+                        <span className="text-xs">{getSortIcon("price")}</span>
                       </div>
                     </th>
-                    <th className="border border-gray-200 px-4 py-2 text-left">追加・削除</th>
+                    <th className="border border-gray-200 px-4 py-2 text-left">
+                      追加・削除
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {sortPricingRules(pricingRules).map((rule, index) => (
-                    <tr key={rule.id} className={`hover:bg-gray-50 ${rowErrorIds.has(rule.id) ? 'border-2 border-red-500' : ''}`}>
+                    <tr
+                      key={rule.id}
+                      className={`hover:bg-gray-50 ${rowErrorIds.has(rule.id) ? "border-2 border-red-500" : ""}`}
+                    >
                       <td className="border border-gray-200 px-4 py-2">
                         <select
                           value={rule.truckType}
-                          onChange={e => updatePricingRule(rule.id, 'truckType', e.target.value)}
+                          onChange={(e) =>
+                            updatePricingRule(
+                              rule.id,
+                              "truckType",
+                              e.target.value,
+                            )
+                          }
                           className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                         >
-                          <option value="">トラック種別を選択</option>
-                          {TRUCK_TYPES.map(type => (
-                            <option key={type} value={type}>{type}</option>
+                          {TRUCK_TYPES.map((type) => (
+                            <option key={type} value={type}>
+                              {type}
+                            </option>
                           ))}
                         </select>
                       </td>
                       <td className="border border-gray-200 px-4 py-2">
                         <div className="flex items-center space-x-2">
-                          <span className="text-gray-600 text-sm bg-gray-100 px-2 py-1 rounded">{rule.minPoint}</span>
+                          <span className="text-gray-600 text-sm bg-gray-100 px-2 py-1 rounded">
+                            {rule.minPoint}
+                          </span>
                           <span className="text-gray-500">～</span>
                           <select
-                            value={rule.maxPoint ?? ''}
-                            onChange={e => updateMaxPoint(rule.id, e.target.value ? parseInt(e.target.value) : 0)}
+                            value={rule.maxPoint ?? ""}
+                            onChange={(e) =>
+                              updateMaxPoint(
+                                rule.id,
+                                e.target.value ? parseInt(e.target.value) : 0,
+                              )
+                            }
                             className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                           >
                             <option value="">最大値</option>
-                            {POINT_RANGE.filter(point => point > rule.minPoint).map(point => (
-                              <option key={point} value={point}>{point}</option>
+                            {POINT_RANGE.filter(
+                              (point) => point > rule.minPoint,
+                            ).map((point) => (
+                              <option key={point} value={point}>
+                                {point}
+                              </option>
                             ))}
                           </select>
                         </div>
@@ -575,8 +703,16 @@ export default function PricingStep1Page() {
                         <input
                           type="number"
                           min="0"
-                          value={rule.price ?? ''}
-                          onChange={e => updatePricingRule(rule.id, 'price', e.target.value ? parseInt(e.target.value) : undefined)}
+                          value={rule.price ?? ""}
+                          onChange={(e) =>
+                            updatePricingRule(
+                              rule.id,
+                              "price",
+                              e.target.value
+                                ? parseInt(e.target.value)
+                                : undefined,
+                            )
+                          }
                           className="w-full min-w-[60px] max-w-[100px] px-1 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 text-right"
                           placeholder="料金"
                         />
@@ -585,7 +721,9 @@ export default function PricingStep1Page() {
                         <button
                           onClick={() => removePricingRule(rule.id)}
                           className="text-red-600 hover:text-red-800 text-sm"
-                        >🗑️ 削除</button>
+                        >
+                          🗑️ 削除
+                        </button>
                       </td>
                     </tr>
                   ))}
@@ -597,7 +735,9 @@ export default function PricingStep1Page() {
 
         {/* 料金計算例 */}
         <div className="bg-gray-50 border border-gray-200 rounded-lg p-4 mt-6">
-          <h3 className="text-lg font-semibold text-gray-800 mb-2">💡 料金設定例</h3>
+          <h3 className="text-lg font-semibold text-gray-800 mb-2">
+            💡 料金設定例
+          </h3>
           <div className="text-sm text-gray-600 space-y-1">
             <p>• 各設定は「トラック種別 × ポイント範囲」で管理</p>
             <p>• ポイント最小値は自動設定（前の行の最大値 + 1）</p>
@@ -608,16 +748,31 @@ export default function PricingStep1Page() {
 
         {/* オプション料金設定 */}
         <div className="bg-white shadow-md rounded-lg p-6 mt-8">
-          <h2 className="text-xl font-semibold text-gray-800 mb-4">🛠️ オプション料金設定</h2>
+          <h2 className="text-xl font-semibold text-gray-800 mb-4">
+            🛠️ オプション料金設定
+          </h2>
           <div className="overflow-x-auto">
             <table className="w-full border-collapse">
               <thead>
                 <tr className="bg-gray-50">
-                  <th className="border border-gray-200 px-4 py-2 text-left">オプション名</th>
-                  <th className="border border-gray-200 px-6 py-2 text-left">種別</th>
-                  <th className="border border-gray-200 px-2 py-2 text-left">金額（円）</th>
-                  <th className="border border-gray-200 px-2 py-2 text-left">単位数量</th>
-                  <th className="border border-gray-200 px-4 py-2 text-left">備考</th>
+                  <th className="border border-gray-200 px-4 py-2 text-left">
+                    オプション名
+                  </th>
+                  <th className="border border-gray-200 px-6 py-2 text-left">
+                    種別
+                  </th>
+                  <th className="border border-gray-200 px-2 py-2 text-left">
+                    金額（円）
+                  </th>
+                  <th className="border border-gray-200 px-2 py-2 text-left">
+                    単位数量
+                  </th>
+                  <th className="border border-gray-200 px-4 py-2 text-left">
+                    備考
+                  </th>
+                  <th className="border border-gray-200 px-4 py-2 text-left">
+                    削除
+                  </th>
                 </tr>
               </thead>
               <tbody>
@@ -630,7 +785,9 @@ export default function PricingStep1Page() {
                         <input
                           type="text"
                           value={opt.label}
-                          onChange={e => handleOptionLabelChange(opt.id, e.target.value)}
+                          onChange={(e) =>
+                            handleOptionLabelChange(opt.id, e.target.value)
+                          }
                           className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                         />
                       )}
@@ -638,67 +795,96 @@ export default function PricingStep1Page() {
                     <td className="border border-gray-200 px-6 py-2">
                       <select
                         value={opt.type}
-                        onChange={e => handleOptionTypeChange(opt.id, e.target.value as OptionType)}
+                        onChange={(e) =>
+                          handleOptionTypeChange(
+                            opt.id,
+                            e.target.value as OptionType,
+                          )
+                        }
                         className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
-                        style={{ whiteSpace: 'nowrap' }}
+                        style={{ whiteSpace: "nowrap" }}
                       >
-                        {OPTION_TYPES.map(t => (
-                          <option key={t.value} value={t.value}>{t.label}</option>
+                        {OPTION_TYPES.map((t) => (
+                          <option key={t.value} value={t.value}>
+                            {t.label}
+                          </option>
                         ))}
                       </select>
                     </td>
                     <td className="border border-gray-200 px-2 py-2">
-                      <input
-                        type="text"
-                        value={opt.type === 'individual' || opt.type === 'free' ? '' : (opt.price ?? 0).toLocaleString()}
-                        onChange={e => {
-                          const value = e.target.value;
-                          if (/[^\u0000-\u007f]+/.test(value)) {
-                            setOptionErrors(prev => ({ ...prev, [opt.id]: '※半角数値のみ' }));
-                            return;
-                          } else {
-                            setOptionErrors(prev => ({ ...prev, [opt.id]: '' }));
-                            const num = value.replace(/,/g, '');
-                            handleOptionPriceChange(opt.id, parseInt(num) || 0);
-                          }
-                        }}
-                        className={`w-full min-w-[60px] max-w-[100px] px-1 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 text-right ${opt.type === 'individual' || opt.type === 'free' ? 'bg-gray-200 cursor-not-allowed' : ''}`}
-                        disabled={opt.type === 'individual' || opt.type === 'free'}
-                      />
+                      {opt.type === "paid" ? (
+                        <input
+                          type="text"
+                          value={(opt.price ?? 0).toLocaleString()}
+                          onChange={(e) => {
+                            const value = e.target.value;
+                            if (/[^\u0000-\u007f]+/.test(value)) {
+                              setOptionErrors((prev) => ({
+                                ...prev,
+                                [opt.id]: "※半角数値のみ",
+                              }));
+                              return;
+                            } else {
+                              setOptionErrors((prev) => ({
+                                ...prev,
+                                [opt.id]: "",
+                              }));
+                              const num = value.replace(/,/g, "");
+                              handleOptionPriceChange(
+                                opt.id,
+                                parseInt(num) || 0,
+                              );
+                            }
+                          }}
+                          className="w-full min-w-[60px] max-w-[100px] px-1 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 text-right"
+                        />
+                      ) : (
+                        <span className="text-gray-500">-</span>
+                      )}
                       {optionErrors[opt.id] && (
-                        <div className="text-red-600 text-xs mt-1">{optionErrors[opt.id]}</div>
+                        <div className="text-red-600 text-xs mt-1">
+                          {optionErrors[opt.id]}
+                        </div>
                       )}
                     </td>
                     <td className="border border-gray-200 px-2 py-2">
-                      {opt.type === 'individual' || opt.type === 'free' || opt.label === '🏠 建物養生（壁や床の保護）' ? (
-                        <select disabled className="w-full min-w-[60px] max-w-[100px] px-1 py-1 border border-gray-300 rounded bg-gray-200 cursor-not-allowed text-right">
-                          <option value=""></option>
-                        </select>
-                      ) : (
+                      {opt.type === "paid" ? (
                         <select
-                          value={opt.unit ?? ''}
-                          onChange={e => handleOptionUnitChange(opt.id, e.target.value)}
+                          value={opt.unit ?? ""}
+                          onChange={(e) =>
+                            handleOptionUnitChange(opt.id, e.target.value)
+                          }
                           className="w-full min-w-[60px] max-w-[100px] px-1 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500 text-right"
                         >
                           <option value=""></option>
                           {[...Array(100)].map((_, i) => (
-                            <option key={i + 1} value={i + 1}>{i + 1}</option>
+                            <option key={i + 1} value={i + 1}>
+                              {i + 1}
+                            </option>
                           ))}
                         </select>
+                      ) : (
+                        <span className="text-gray-500">-</span>
                       )}
                     </td>
                     <td className="border border-gray-200 px-4 py-2">
                       <input
                         type="text"
-                        value={opt.remarks ?? ''}
-                        onChange={e => handleOptionRemarksChange(opt.id, e.target.value)}
+                        value={opt.remarks ?? ""}
+                        onChange={(e) =>
+                          handleOptionRemarksChange(opt.id, e.target.value)
+                        }
                         className="w-full px-2 py-1 border border-gray-300 rounded focus:ring-blue-500 focus:border-blue-500"
                       />
+                    </td>
+                    <td className="border border-gray-200 px-4 py-2 text-center">
                       {!opt.isDefault && (
                         <button
                           onClick={() => handleDeleteOption(opt.id)}
                           className="text-red-600 hover:text-red-800 text-sm"
-                        >🗑️ 削除</button>
+                        >
+                          🗑️ 削除
+                        </button>
                       )}
                     </td>
                   </tr>
@@ -711,60 +897,53 @@ export default function PricingStep1Page() {
             <input
               type="text"
               value={newOptionLabel}
-              onChange={e => setNewOptionLabel(e.target.value)}
+              onChange={(e) => setNewOptionLabel(e.target.value)}
               className="border rounded px-3 py-1 flex-1 min-w-[180px]"
               placeholder="新しいオプション名"
             />
             <select
               value={newOptionType}
-              onChange={e => setNewOptionType(e.target.value as OptionType)}
+              onChange={(e) => setNewOptionType(e.target.value as OptionType)}
               className="border rounded px-2 py-1 min-w-[120px]"
             >
-              {OPTION_TYPES.map(t => (
-                <option key={t.value} value={t.value}>{t.label}</option>
+              {OPTION_TYPES.map((t) => (
+                <option key={t.value} value={t.value}>
+                  {t.label}
+                </option>
               ))}
             </select>
-            {newOptionType === 'paid' && (
+            {newOptionType === "paid" && (
               <input
                 type="text"
                 min="0"
                 value={newOptionPrice}
-                onChange={e => setNewOptionPrice(parseInt(e.target.value) || 0)}
+                onChange={(e) =>
+                  setNewOptionPrice(parseInt(e.target.value) || 0)
+                }
                 className="border rounded px-2 py-1 min-w-[80px]"
                 placeholder="金額"
               />
             )}
-            <input
-              type="text"
-              value={newOptionUnit}
-              onChange={e => setNewOptionUnit(e.target.value)}
-              className="border rounded px-2 py-1 min-w-[80px]"
-              placeholder="単位数量"
-            />
-            <input
-              type="number"
-              min="0"
-              value={newPricingMaxPoint ?? ''}
-              onChange={e => setNewPricingMaxPoint(e.target.value ? parseInt(e.target.value) : undefined)}
-              className="border rounded px-2 py-1 min-w-[60px] max-w-[100px] text-right"
-              placeholder="最大値"
-            />
-            <input
-              type="number"
-              min="0"
-              value={newPricingPrice ?? ''}
-              onChange={e => setNewPricingPrice(e.target.value ? parseInt(e.target.value) : undefined)}
-              className="border rounded px-2 py-1 min-w-[60px] max-w-[100px] text-right"
-              placeholder="料金"
-            />
+            {newOptionType === "paid" && (
+              <input
+                type="text"
+                value={newOptionUnit}
+                onChange={(e) => setNewOptionUnit(e.target.value)}
+                className="border rounded px-2 py-1 min-w-[80px]"
+                placeholder="単位数量"
+              />
+            )}
             <button
               type="button"
               onClick={handleAddOption}
               className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-1 rounded transition"
-            >追加</button>
+            >
+              追加
+            </button>
           </div>
-          {isAddOptionMinMaxError && <div className="text-red-600 text-xs mt-1">※ 最小値・最大値は必須かつ最大値は最小値より大きい値を入力してください</div>}
-          {optionAddError && <div className="text-red-600 text-sm mt-2">{optionAddError}</div>}
+          {optionAddError && (
+            <div className="text-red-600 text-sm mt-2">{optionAddError}</div>
+          )}
         </div>
 
         {/* ナビゲーション */}
@@ -785,4 +964,4 @@ export default function PricingStep1Page() {
       </div>
     </main>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- adjust POINT_RANGE to 1..1000
- hide price/unit fields for non-paid options
- rework option table with dedicated delete column
- clean up option add form and validations

## Testing
- `npx eslint --version`
- `npm run lint` *(fails: `next` not found)*
- `npx next lint` *(fails: 403 Forbidden)*
- `npm run build` *(fails: `next` not found)*
- `npx next build` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686ab9d5e1a88332a3ae7b1287c4275a