### PR TITLE
Improve shift calendar usability

### DIFF
--- a/src/app/admin/notifications/page.tsx
+++ b/src/app/admin/notifications/page.tsx
@@ -173,7 +173,7 @@ export default function AdminNotifications() {
    * @param requestId - 依頼ID
    */
   const handleAnswer = (requestId: string) => {
-    console.log('Answer request:', requestId);
+    // TODO: implement answer logic
   };
 
   /**
@@ -181,7 +181,7 @@ export default function AdminNotifications() {
    * @param requestId - 依頼ID
    */
   const handleViewDetails = (requestId: string) => {
-    console.log('View details for request:', requestId);
+    // TODO: navigate to details view
   };
 
   /**


### PR DESCRIPTION
## Summary
- add hover '+' hint for empty calendar cells
- provide quick instructions on adding shifts
- remove leftover console logs from admin notifications

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68837bff90e483329a8d51de98ca3c8a