### PR TITLE
Fix calendar date navigation

### DIFF
--- a/src/components/DispatchCalendar.tsx
+++ b/src/components/DispatchCalendar.tsx
@@ -7,7 +7,7 @@
  * - 案件の追加・編集・削除
  */
 import { useState, useEffect } from 'react';
-import { formatDate, formatTime } from '@/utils/dateTimeUtils';
+import { formatDate, formatTime, toLocalDateString } from '@/utils/dateTimeUtils';
 import { WEEKDAYS_JA, VIEW_MODE_LABELS } from '../constants/calendar';
 import CaseDetail from './CaseDetail';
 
@@ -129,7 +129,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
       const currentDate = new Date(startOfWeek);
       currentDate.setDate(startOfWeek.getDate() + i);
       days.push({
-        date: currentDate.toISOString().split('T')[0],
+        date: toLocalDateString(currentDate),
         day: currentDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[i],
         isToday: currentDate.toDateString() === new Date().toDateString(),
@@ -158,7 +158,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
       const prevMonthLastDay = new Date(year, month, 0).getDate();
       const prevDate = new Date(year, month - 1, prevMonthLastDay - i);
       days.push({
-        date: prevDate.toISOString().split('T')[0],
+        date: toLocalDateString(prevDate),
         day: prevDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[prevDate.getDay()],
         isCurrentMonth: false,
@@ -170,7 +170,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
     for (let day = 1; day <= daysInMonth; day++) {
       const currentDate = new Date(year, month, day);
       days.push({
-        date: currentDate.toISOString().split('T')[0],
+        date: toLocalDateString(currentDate),
         day: day,
         dayOfWeek: WEEKDAYS_JA[currentDate.getDay()],
         isCurrentMonth: true,
@@ -183,7 +183,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
     for (let day = 1; day <= remainingDays; day++) {
       const nextDate = new Date(year, month + 1, day);
       days.push({
-        date: nextDate.toISOString().split('T')[0],
+        date: toLocalDateString(nextDate),
         day: nextDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[nextDate.getDay()],
         isCurrentMonth: false,
@@ -202,7 +202,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
   const getDayView = (date: Date) => {
     const currentDate = new Date(date);
     return {
-      date: currentDate.toISOString().split('T')[0],
+      date: toLocalDateString(currentDate),
       day: currentDate.getDate(),
       dayOfWeek: WEEKDAYS_JA[currentDate.getDay()],
       month: currentDate.getMonth() + 1, // 月（1-12）
@@ -349,7 +349,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
   const goToToday = () => {
     const today = new Date();
     setCurrentDate(today);
-    setSelectedDate(today.toISOString().split('T')[0]);
+    setSelectedDate(toLocalDateString(today));
   };
 
   /**
@@ -357,7 +357,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
    */
   const ScheduleModal = () => {
     const [formData, setFormData] = useState({
-      date: selectedDate || new Date().toISOString().split('T')[0],
+      date: selectedDate || toLocalDateString(new Date()),
       startTime: '09:00',
       endTime: '10:00',
       customerName: '',
@@ -992,7 +992,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
               onClick={() => {
                 const prevDate = new Date(currentDayView.date);
                 prevDate.setDate(prevDate.getDate() - 1);
-                setSelectedDate(prevDate.toISOString().split('T')[0]);
+                setSelectedDate(toLocalDateString(prevDate));
               }}
               className="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors"
             >
@@ -1002,7 +1002,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
               onClick={() => {
                 const nextDate = new Date(currentDayView.date);
                 nextDate.setDate(nextDate.getDate() + 1);
-                setSelectedDate(nextDate.toISOString().split('T')[0]);
+                setSelectedDate(toLocalDateString(nextDate));
               }}
               className="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded hover:bg-gray-200 transition-colors"
             >
@@ -1804,7 +1804,7 @@ export default function DispatchCalendar({ trucks, onUpdateTruck }: DispatchCale
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {trucks.map(truck => {
               const nextSchedule = truck.schedules
-                .filter(s => s.date >= new Date().toISOString().split('T')[0])
+                .filter(s => s.date >= toLocalDateString(new Date()))
                 .sort((a, b) => a.date.localeCompare(b.date))[0];
 
               return (

--- a/src/components/ShiftCalendar.tsx
+++ b/src/components/ShiftCalendar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { formatDate } from '@/utils/dateTimeUtils';
+import { formatDate, toLocalDateString } from '@/utils/dateTimeUtils';
 import { WEEKDAYS_JA, TIME_SLOTS, SHIFT_STATUS } from '@/constants/calendar';
 
 interface Employee {
@@ -93,7 +93,7 @@ export default function ShiftCalendar({
       const currentDate = new Date(startOfWeek);
       currentDate.setDate(startOfWeek.getDate() + i);
       days.push({
-        date: currentDate.toISOString().split('T')[0],
+        date: toLocalDateString(currentDate),
         day: currentDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[i],
         isToday: currentDate.toDateString() === new Date().toDateString(),
@@ -117,7 +117,7 @@ export default function ShiftCalendar({
     for (let i = startingDayOfWeek - 1; i >= 0; i--) {
       const prevDate = new Date(year, month, -i);
       days.push({
-        date: prevDate.toISOString().split('T')[0],
+        date: toLocalDateString(prevDate),
         day: prevDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[prevDate.getDay()],
         isCurrentMonth: false,
@@ -130,7 +130,7 @@ export default function ShiftCalendar({
     for (let day = 1; day <= daysInMonth; day++) {
       const currentDate = new Date(year, month, day);
       days.push({
-        date: currentDate.toISOString().split('T')[0],
+        date: toLocalDateString(currentDate),
         day: day,
         dayOfWeek: WEEKDAYS_JA[currentDate.getDay()],
         isCurrentMonth: true,
@@ -144,7 +144,7 @@ export default function ShiftCalendar({
     for (let day = 1; day <= remainingDays; day++) {
       const nextDate = new Date(year, month + 1, day);
       days.push({
-        date: nextDate.toISOString().split('T')[0],
+        date: toLocalDateString(nextDate),
         day: nextDate.getDate(),
         dayOfWeek: WEEKDAYS_JA[nextDate.getDay()],
         isCurrentMonth: false,
@@ -397,7 +397,7 @@ export default function ShiftCalendar({
   const goToToday = () => {
     const today = new Date();
     setCurrentDate(today);
-    setSelectedDate(today.toISOString().split('T')[0]);
+    setSelectedDate(toLocalDateString(today));
   };
 
   const copyPreviousWeek = () => {
@@ -421,7 +421,7 @@ export default function ShiftCalendar({
           newDate.setDate(newDate.getDate() + 7);
           const newShift = {
             ...shift,
-            date: newDate.toISOString().split('T')[0],
+            date: toLocalDateString(newDate),
             status: 'provisional' as const,
           };
           onAddShift(employee.id, newShift);

--- a/src/utils/dateTimeUtils.ts
+++ b/src/utils/dateTimeUtils.ts
@@ -24,4 +24,16 @@ export const formatDate = (dateString: string): string => {
 export const formatTime = (time: string): string => {
   const [hours, minutes] = time.split(':');
   return `${hours}:${minutes}`;
-}; 
+};
+
+/**
+ * DateオブジェクトをローカルタイムゾーンのYYYY-MM-DD形式に変換する
+ * @param date - Dateオブジェクト
+ * @returns YYYY-MM-DD形式の日付文字列
+ */
+export const toLocalDateString = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};


### PR DESCRIPTION
## Summary
- add `toLocalDateString` helper to format dates without timezone shifts
- use helper when generating calendar days and navigation dates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885c74f35f88332844bc28115a27ae6