### PR TITLE
fix: type AnimatedCard variants

### DIFF
--- a/src/components/animations/AnimatedCard.tsx
+++ b/src/components/animations/AnimatedCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, Variants } from 'framer-motion';
 
 interface AnimatedCardProps {
   children: React.ReactNode;
@@ -14,7 +14,7 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({
   className = '',
   whileHover = true
 }) => {
-  const cardVariants = {
+  const cardVariants: Variants = {
     hidden: {
       opacity: 0,
       y: 50,
@@ -33,22 +33,26 @@ export const AnimatedCard: React.FC<AnimatedCardProps> = ({
     }
   };
 
-  const hoverVariants = whileHover ? {
-    hover: {
-      y: -10,
-      scale: 1.02,
-      transition: {
-        type: "spring",
-        damping: 15,
-        stiffness: 300
+  const hoverVariants: Variants = whileHover
+    ? {
+        hover: {
+          y: -10,
+          scale: 1.02,
+          transition: {
+            type: "spring",
+            damping: 15,
+            stiffness: 300
+          }
+        }
       }
-    }
-  } : {};
+    : {};
+
+  const variants: Variants = { ...cardVariants, ...hoverVariants };
 
   return (
     <motion.div
       className={className}
-      variants={{ ...cardVariants, ...hoverVariants }}
+      variants={variants}
       initial="hidden"
       whileInView="visible"
       whileHover={whileHover ? "hover" : undefined}


### PR DESCRIPTION
## Summary
- fix AnimatedCard variants typing by using framer-motion `Variants`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run build` *(fails: Failed to fetch font `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6899b91941588332a4becc47f72cc27d