### PR TITLE
Fix AnimatedText transition type

### DIFF
--- a/src/components/animations/AnimatedText.tsx
+++ b/src/components/animations/AnimatedText.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import { motion } from 'framer-motion';
+import { motion, Variants } from 'framer-motion';
 
 interface AnimatedTextProps {
   text: string;
   className?: string;
   delay?: number;
-  duration?: number;
   type?: 'word' | 'character';
 }
 
@@ -13,12 +12,11 @@ export const AnimatedText: React.FC<AnimatedTextProps> = ({
   text,
   className = '',
   delay = 0,
-  duration = 0.5,
   type = 'word'
 }) => {
   const words = text.split(' ');
 
-  const container = {
+  const container: Variants = {
     hidden: { opacity: 0 },
     visible: (i = 1) => ({
       opacity: 1,
@@ -26,15 +24,14 @@ export const AnimatedText: React.FC<AnimatedTextProps> = ({
     }),
   };
 
-  const child = {
+  const child: Variants = {
     visible: {
       opacity: 1,
       y: 0,
       transition: {
         type: "spring",
         damping: 12,
-        stiffness: 200,
-        duration
+        stiffness: 200
       }
     },
     hidden: {


### PR DESCRIPTION
## Summary
- refactor AnimatedText variants with proper typings
- remove unused duration prop and rely on spring transition defaults

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: Failed to fetch `Geist` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6899c4d9b3f08332bdfb39ce78ea0a08