### PR TITLE
Fix animation frame ref initialization

### DIFF
--- a/src/components/animations/ParticleBackground.tsx
+++ b/src/components/animations/ParticleBackground.tsx
@@ -12,7 +12,7 @@ interface Particle {
 export const ParticleBackground: React.FC = () => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const particlesRef = useRef<Particle[]>([]);
-  const animationRef = useRef<number>();
+  const animationRef = useRef<number | null>(null);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -89,7 +89,7 @@ export const ParticleBackground: React.FC = () => {
 
     return () => {
       window.removeEventListener('resize', resizeCanvas);
-      if (animationRef.current) {
+      if (animationRef.current !== null) {
         cancelAnimationFrame(animationRef.current);
       }
     };


### PR DESCRIPTION
## Summary
- initialize animation frame reference with null
- guard animation cleanup with explicit null check

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Geist`)*
- `npx tsc --noEmit`
- `npm run lint` *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6899c78ae604833290c88cdf086ea13d