### PR TITLE
fix: omit packing deadline when not applicable

### DIFF
--- a/src/app/admin/cases/lib/unifiedData.ts
+++ b/src/app/admin/cases/lib/unifiedData.ts
@@ -315,7 +315,13 @@ export function generateUnifiedTestData(): UnifiedCase[] {
         priority: ['high', 'medium', 'low'][i % 3] as any,
         sourceType: sourceType as any,
         packingDelivery: i % 3 !== 0, // 3件に1件は配送無し
-        packingDeadline: i % 3 !== 0 ? new Date(targetDate.getTime() - 5 * 24 * 60 * 60 * 1000).toISOString().split('T')[0] : undefined
+        ...(i % 3 !== 0
+          ? {
+              packingDeadline: new Date(targetDate.getTime() - 5 * 24 * 60 * 60 * 1000)
+                .toISOString()
+                .split('T')[0]
+            }
+          : {})
       });
     } else {
       // 履歴データ
@@ -355,7 +361,13 @@ export function generateUnifiedTestData(): UnifiedCase[] {
         amountWithTax: amount,
         isReQuote: i % 7 === 0,
         packingDelivery: i % 4 !== 0, // 4件に1件は配送無し
-        packingDeadline: i % 4 !== 0 ? new Date(targetDate.getTime() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0] : undefined,
+        ...(i % 4 !== 0
+          ? {
+              packingDeadline: new Date(targetDate.getTime() - 7 * 24 * 60 * 60 * 1000)
+                .toISOString()
+                .split('T')[0]
+            }
+          : {}),
         sourceType: sourceType as any
       });
     }


### PR DESCRIPTION
## Summary
- avoid assigning `undefined` to `packingDeadline` in unified test data
- include `packingDeadline` only when packing material delivery is requested

## Testing
- `npm run typecheck:strict`
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Inter` font from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68c2c1dac0c8833295a8b8043daa208e