### PR TITLE
fix: close main element in admin case register page

### DIFF
--- a/src/app/admin/cases/register/page.tsx
+++ b/src/app/admin/cases/register/page.tsx
@@ -144,9 +144,8 @@ export default function CaseRegistrationPage() {
                 </div>
               </div>
             </div>
-          </div>
-        </main>
-      </div>
-    </AdminAuthGuard>
+          </main>
+        </div>
+      </AdminAuthGuard>
   );
-} 
+}


### PR DESCRIPTION
## Summary
- fix JSX structure for `/admin/cases/register` by removing stray closing tag and closing `<main>` properly

## Testing
- `npm run typecheck:strict`
- `npm run lint`
- `npm test`
- `npm run build` *(fails: Failed to fetch font `Inter`)*

------
https://chatgpt.com/codex/tasks/task_e_68c753f4fad483328cbf98190119a63e